### PR TITLE
Update repositories.txt

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -6118,3 +6118,4 @@ https://github.com/iory/i2c-for-esp32
 https://github.com/abcdaaaaaaaaa/MQSpaceData.h
 https://github.com/casiez/OneEuroFilterArduino
 https://github.com/EvTheFuture/WebConsole
+https://gitlab.com/riscv-vega/vega-sensor-libraries/display/vega_chainableled


### PR DESCRIPTION
library for Grove Chainable RGB LED v2.0 for VEGA ARIES Boards and other